### PR TITLE
Add direction option for Mermaid diagram and update tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,31 @@ The analysis results are output to standard output in Mermaid format as shown be
 The following example shows that s3import.yaml references MyBucketExportName, which is exported in s3export.yaml.  
 
 ```mermaid
-graph BT
+graph LR
     s3import.yaml-->|MyBucketExportName|s3export.yaml
 ```
 
-Use the -d option to specify the directory where the CFn templates are saved.  
+Use the `-d` option to specify the directory where the CFn templates are saved.  
 
 ```bash
 cfn-tdv -d examples/yaml/
 ```
 
-To output the analysis results to a file, specify the -o option.  
+To output the analysis results to a file, specify the `-o` option.  
 
 ```bash
 cfn-tdv -o result.md
+```
+
+You can specify the direction of the Mermaid diagram using the `-D` or `--direction` option.  
+The default is `LR` (left to right).  
+You can also choose `BT` (bottom to top).
+
+- `-D LR` : Left to right (default)
+- `-D BT` : Bottom to top
+
+```bash
+cfn-tdv -D BT
 ```
 
 ## Detecting self-references
@@ -50,7 +61,7 @@ cfn-tdv -d examples/yml
 ```
 
 ```mermaid
-graph BT
+graph LR
     vpc.yml-->|VpcStackSecurityGroup|vpc.yml
     vpc.yml-->|VpcStackPublicSubnet|vpc.yml
     instanceprofile.yml-->|ArnS3Bucket|s3.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cfn-template-dependency-visualization"
-version = "0.0.1"
+version = "0.0.2"
 requires-python = ">=3.12"
 dependencies =  [
     "cfn-flip >= 1.3.0",

--- a/src/cfntdv/main.py
+++ b/src/cfntdv/main.py
@@ -40,6 +40,16 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Output detailed logs",
     )
+    parser.add_argument(
+        "-D",
+        "--direction",
+        default="LR",
+        choices=["LR", "BT"],
+        help=(
+            "Direction of Mermaid diagram (LR: Left to right, BT: Bottom to top). "
+            "Default: LR"
+        ),
+    )
     return parser.parse_args(args=sys.argv[1:])
 
 
@@ -135,9 +145,20 @@ def check_self_reference(template_info: dict) -> None:
                 )
 
 
-def generate_mermaid_text(edges: list, output_file: str | None = None) -> None:
-    """Generate and output Mermaid diagram text."""
-    mermaid_lines = ["# CFn template dependency\n\n```mermaid", "graph BT"]
+def generate_mermaid_text(
+    edges: list,
+    output_file: str | Path | None = None,
+    direction: str = "LR",
+) -> None:
+    """Generate and output Mermaid diagram text.
+
+    Args:
+        edges (list): List of tuples representing dependencies in the form (source, destination, import_value).
+        output_file (str | None, optional): If specified, the Mermaid diagram will be written to this file; otherwise, output is printed to stdout.
+        direction (str, optional): Direction of the Mermaid diagram ('LR' for left-to-right, 'BT' for bottom-to-top). Default is 'LR'.
+
+    """  # noqa: E501
+    mermaid_lines = ["# CFn template dependency\n\n```mermaid", f"graph {direction}"]
     for src, dst, imp in edges:
         mermaid_lines.append(f"    {Path(src).name}-->|{imp}|{Path(dst).name}")
     mermaid_lines.append("```\n")
@@ -157,7 +178,7 @@ def main() -> None:
     template_info = collect_template_info(templates, verbose=args.verbose)
     _, edges = build_dependency_graph(template_info)
     check_self_reference(template_info)
-    generate_mermaid_text(edges, args.output_file)
+    generate_mermaid_text(edges, args.output_file, direction=args.direction)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Introduce a new option to specify the direction of the Mermaid diagram in the CLI, allowing users to choose between left-to-right and bottom-to-top layouts. Update tests to validate the new functionality.