### PR TITLE
Add support for dynamic references in CloudFormation templates and update tests

### DIFF
--- a/examples/yaml/result.md
+++ b/examples/yaml/result.md
@@ -1,6 +1,6 @@
 # CFn template dependency
 
 ```mermaid
-graph BT
+graph LR
     s3import.yaml-->|MyBucketExportName|s3export.yaml
 ```

--- a/examples/yml/ec2.yml
+++ b/examples/yml/ec2.yml
@@ -17,3 +17,19 @@ Resources:
       AvailabilityZone: ap-northeast-1a
       ImageId: ami-0ff21806645c5e492
       IamInstanceProfile: !ImportValue InstanceProfileName
+
+  MyLaunchTemplate01:
+    Type: AWS::EC2::LaunchTemplate
+    Properties: 
+      LaunchTemplateName: !Sub ${AWS::StackName}-launch-template
+      LaunchTemplateData:
+        ImageId: '{{resolve:ssm:golden-ami:2}}'
+        InstanceType: t2.micro
+
+  MyLaunchTemplate02:
+    Type: AWS::EC2::LaunchTemplate
+    Properties: 
+      LaunchTemplateName: !Sub ${AWS::StackName}-launch-template
+      LaunchTemplateData:
+        ImageId: '{{resolve:ssm:golden-ami}}'
+        InstanceType: t2.micro

--- a/examples/yml/iam.yml
+++ b/examples/yml/iam.yml
@@ -1,0 +1,15 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  MyIAMUser01:
+    Type: AWS::IAM::User
+    Properties:
+      UserName: 'MyUserName'
+      LoginProfile:
+        Password: '{{resolve:ssm-secure:IAMUserPassword:10}}'
+
+  MyIAMUser02:
+    Type: AWS::IAM::User
+    Properties:
+      UserName: 'MyUserName'
+      LoginProfile:
+        Password: '{{resolve:ssm-secure:IAMUserPassword}}'

--- a/examples/yml/rds.yml
+++ b/examples/yml/rds.yml
@@ -1,0 +1,21 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  MyRDSInstance01:
+    Type: 'AWS::RDS::DBInstance'
+    Properties:
+      DBName: MyRDSInstance
+      AllocatedStorage: '20'
+      DBInstanceClass: db.t2.micro
+      Engine: mysql
+      MasterUsername: '{{resolve:secretsmanager:MySecret:SecretString:username}}'
+      MasterUserPassword: '{{resolve:secretsmanager:MySecret:SecretString:password:2}}'
+
+  MyRDSInstance02:
+    Type: 'AWS::RDS::DBInstance'
+    Properties:
+      DBName: MyRDSInstance
+      AllocatedStorage: '20'
+      DBInstanceClass: db.t2.micro
+      Engine: mysql
+      MasterUsername: '{{resolve:secretsmanager:arn:aws:secretsmanager:us-west-2:123456789012:secret:MySecret:SecretString:username}}'
+      MasterUserPassword: '{{resolve:secretsmanager:arn:aws:secretsmanager:us-west-2:123456789012:secret:MySecret:SecretString:password:2}}'

--- a/examples/yml/result.md
+++ b/examples/yml/result.md
@@ -1,11 +1,19 @@
 # CFn template dependency
 
 ```mermaid
-graph BT
-    vpc.yml-->|VpcStackSecurityGroup|vpc.yml
-    vpc.yml-->|VpcStackPublicSubnet|vpc.yml
-    instanceprofile.yml-->|ArnS3Bucket|s3.yml
-    ec2.yml-->|VpcStackSecurityGroup|vpc.yml
-    ec2.yml-->|VpcStackPublicSubnet|vpc.yml
+graph LR
     ec2.yml-->|InstanceProfileName|instanceprofile.yml
+    ec2.yml-->|VpcStackPublicSubnet|vpc.yml
+    ec2.yml-->|VpcStackSecurityGroup|vpc.yml
+    ec2.yml-->|ssm|golden-ami:2[(golden-ami:2)]
+    ec2.yml-->|ssm|golden-ami[(golden-ami)]
+    iam.yml-->|ssm-secure|IAMUserPassword:10[(IAMUserPassword:10)]
+    iam.yml-->|ssm-secure|IAMUserPassword[(IAMUserPassword)]
+    instanceprofile.yml-->|ArnS3Bucket|s3.yml
+    rds.yml-->|secretsmanager|MySecret:SecretString:password:2[(MySecret:SecretString:password:2)]
+    rds.yml-->|secretsmanager|MySecret:SecretString:username[(MySecret:SecretString:username)]
+    rds.yml-->|secretsmanager|arn:aws:secretsmanager:us-west-2:123456789012:secret:MySecret:SecretString:password:2[(arn:aws:secretsmanager:us-west-2:123456789012:secret:MySecret:SecretString:password:2)]
+    rds.yml-->|secretsmanager|arn:aws:secretsmanager:us-west-2:123456789012:secret:MySecret:SecretString:username[(arn:aws:secretsmanager:us-west-2:123456789012:secret:MySecret:SecretString:username)]
+    vpc.yml-->|VpcStackPublicSubnet|vpc.yml
+    vpc.yml-->|VpcStackSecurityGroup|vpc.yml
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cfn-template-dependency-visualization"
-version = "0.0.2"
+version = "0.0.3"
 requires-python = ">=3.12"
 dependencies =  [
     "cfn-flip >= 1.3.0",

--- a/test/Python/test_main.py
+++ b/test/Python/test_main.py
@@ -142,6 +142,29 @@ def test_extract_exports_and_imports_importvalue_list() -> None:
         assert "TagExport2" in result["imports"]  # noqa: S101
 
 
+def test_extract_exports_and_imports_dynamic_reference() -> None:
+    """Test extracting dynamic references from a CloudFormation template."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "dynamic.yaml"
+        content = {
+            "Resources": {
+                "MyRes": {
+                    "Type": "AWS::S3::Bucket",
+                    "Properties": {
+                        "BucketName": "{{resolve:ssm-secure:MyParam:1}}",
+                        "Tags": [
+                            {"Key": "foo", "Value": "{{resolve:ssm:TagParam:latest}}"},
+                        ],
+                    },
+                },
+            },
+        }
+        create_yaml(path, content)
+        result = extract_exports_and_imports(path)
+        assert "{{resolve:ssm-secure:MyParam:1}}" in result["dynamics"]  # noqa: S101
+        assert "{{resolve:ssm:TagParam:latest}}" in result["dynamics"]  # noqa: S101
+
+
 EXPECTED_TEMPLATE_COUNT = 2
 
 
@@ -191,8 +214,18 @@ def test_build_dependency_graph() -> None:
     assert "Export2" in nodes  # noqa: S101
     assert isinstance(edges, list)  # noqa: S101
     assert len(edges) == EXPECTED_EDGE_COUNT  # noqa: S101
-    assert ("template2.yaml", "template1.yaml", "Export1") in edges  # noqa: S101
-    assert ("template3.yaml", "template2.yaml", "Export2") in edges  # noqa: S101
+    assert (  # noqa: S101
+        "template2.yaml",
+        "template1.yaml",
+        "Export1",
+        "import",
+    ) in edges
+    assert (  # noqa: S101
+        "template3.yaml",
+        "template2.yaml",
+        "Export2",
+        "import",
+    ) in edges
 
 
 def test_check_self_reference() -> None:
@@ -226,27 +259,26 @@ def test_check_self_reference_no_warning() -> None:
 def test_generate_mermaid_text() -> None:
     """Test the generate_mermaid_text function."""
     edges = [
-        ("template1.yaml", "template2.yaml", "Export1"),
-        ("template2.yaml", "template3.yaml", "Export2"),
+        ("template1.yaml", "template2.yaml", "Export1", "import"),
+        ("template2.yaml", "template3.yaml", "Export2", "import"),
     ]
     captured_output = io.StringIO()
     sys.stdout = captured_output
-    generate_mermaid_text(edges)  # デフォルトはLR
+    generate_mermaid_text(edges)
     sys.stdout = sys.__stdout__
-    assert captured_output.getvalue().startswith(  # noqa: S101
-        "# CFn template dependency\n\n```mermaid",
-    )
-    assert "graph LR" in captured_output.getvalue()  # noqa: S101
-    assert "template1.yaml-->|Export1|template2.yaml" in captured_output.getvalue()  # noqa: S101
-    assert "template2.yaml-->|Export2|template3.yaml" in captured_output.getvalue()  # noqa: S101
-    assert captured_output.getvalue().endswith("```\n\n")  # noqa: S101
+    out = captured_output.getvalue()
+    assert out.startswith("# CFn template dependency\n\n```mermaid")  # noqa: S101
+    assert "graph LR" in out  # noqa: S101
+    assert "template1.yaml-->|Export1|template2.yaml" in out  # noqa: S101
+    assert "template2.yaml-->|Export2|template3.yaml" in out  # noqa: S101
+    assert out.endswith("```\n\n")  # noqa: S101
 
 
 def test_generate_mermaid_text_bt() -> None:
     """Test the generate_mermaid_text function with BT direction."""
     edges = [
-        ("template1.yaml", "template2.yaml", "Export1"),
-        ("template2.yaml", "template3.yaml", "Export2"),
+        ("template1.yaml", "template2.yaml", "Export1", "import"),
+        ("template2.yaml", "template3.yaml", "Export2", "import"),
     ]
     captured_output = io.StringIO()
     sys.stdout = captured_output
@@ -258,8 +290,8 @@ def test_generate_mermaid_text_bt() -> None:
 def test_generate_mermaid_text_with_output_file() -> None:
     """Test the generate_mermaid_text function with an output file."""
     edges = [
-        ("template1.yaml", "template2.yaml", "Export1"),
-        ("template2.yaml", "template3.yaml", "Export2"),
+        ("template1.yaml", "template2.yaml", "Export1", "import"),
+        ("template2.yaml", "template3.yaml", "Export2", "import"),
     ]
     with tempfile.TemporaryDirectory() as tmpdir:
         output_file = Path(tmpdir) / "output.md"
@@ -277,8 +309,8 @@ def test_generate_mermaid_text_with_output_file() -> None:
 def test_generate_mermaid_text_with_output_file_default_direction() -> None:
     """Test generate_mermaid_text writes 'graph LR' when direction is omitted and writing to a file."""  # noqa: E501
     edges = [
-        ("template1.yaml", "template2.yaml", "Export1"),
-        ("template2.yaml", "template3.yaml", "Export2"),
+        ("template1.yaml", "template2.yaml", "Export1", "import"),
+        ("template2.yaml", "template3.yaml", "Export2", "import"),
     ]
     with tempfile.TemporaryDirectory() as tmpdir:
         output_file = Path(tmpdir) / "output_default.md"
@@ -287,3 +319,56 @@ def test_generate_mermaid_text_with_output_file_default_direction() -> None:
         with output_file.open() as f:
             mermaid_text = f.read()
             assert "graph LR" in mermaid_text  # noqa: S101
+
+
+def test_build_dependency_graph_dynamic_reference() -> None:
+    """Test build_dependency_graph includes dynamic reference edges."""
+    template_info = {
+        "dynamic.yaml": {
+            "exports": [],
+            "imports": [],
+            "dynamics": [
+                "{{resolve:ssm-secure:MyParam:1}}",
+                "{{resolve:ssm:TagParam:latest}}",
+            ],
+        },
+    }
+    nodes, edges = build_dependency_graph(template_info)
+    dynamic_edges = [e for e in edges if e[3] == "dynamic"]
+    assert (  # noqa: S101
+        "dynamic.yaml",
+        "{{resolve:ssm-secure:MyParam:1}}",
+        "{{resolve:ssm-secure:MyParam:1}}",
+        "dynamic",
+    ) in dynamic_edges
+    assert (  # noqa: S101
+        "dynamic.yaml",
+        "{{resolve:ssm:TagParam:latest}}",
+        "{{resolve:ssm:TagParam:latest}}",
+        "dynamic",
+    ) in dynamic_edges
+
+
+def test_generate_mermaid_text_dynamic_reference() -> None:
+    """Test generate_mermaid_text outputs cylindrical shape for dynamic references."""
+    edges = [
+        (
+            "dynamic.yaml",
+            "{{resolve:ssm-secure:MyParam:1}}",
+            "{{resolve:ssm-secure:MyParam:1}}",
+            "dynamic",
+        ),
+        (
+            "dynamic.yaml",
+            "{{resolve:ssm:TagParam:latest}}",
+            "{{resolve:ssm:TagParam:latest}}",
+            "dynamic",
+        ),
+    ]
+    captured_output = io.StringIO()
+    sys.stdout = captured_output
+    generate_mermaid_text(edges)
+    sys.stdout = sys.__stdout__
+    out = captured_output.getvalue()
+    assert "dynamic.yaml-->|ssm-secure|MyParam:1[(MyParam:1)]" in out  # noqa: S101
+    assert "dynamic.yaml-->|ssm|TagParam:latest[(TagParam:latest)]" in out  # noqa: S101


### PR DESCRIPTION
- Enhance README with details on dynamic references and their Mermaid representation.
- Modify `ec2.yml`, `iam.yml`, and `rds.yml` to include dynamic references.
- Update Mermaid output generation to visualize dynamic references as cylindrical nodes.
- Add unit tests for dynamic reference extraction and Mermaid output.